### PR TITLE
fix typos

### DIFF
--- a/a.c
+++ b/a.c
@@ -3,7 +3,7 @@
 
                                                     //! above is a brief description of k/simple system by atw:
                                                     //! he says:       he means:
-                                                    //! fF[+-!#,@]     we have 6 verbs [+ - ! # , @ |] in both monadic and dyadic contexts, total of 14
+                                                    //! fF[+-!#,@|]    we have 7 verbs [+ - ! # , @ |] in both monadic and dyadic contexts, total of 14
                                                     //!                (since monadic + and dyadic | are nyi, we actually have 12, feel free to implement f[+]/F[|])
                                                     //! atom/vector    k/simple sports atoms and vectors!
                                                     //! 1byteint       the only supported atom/vector type is 8bit integer, so beware of overflows
@@ -63,7 +63,7 @@ F(Add,                                              //!< dyadic f+y is add. oper
 
 F(Sub,Add(f,sub(x)))                                //!< dyadic f-x is subtract. since we already have Add() and sub(), we get Sub() for free by negating x.
 F(Mod,Qr(!f||!af)ax?x%f:_x(N(nx,xi%f)))             //!< dyadic f!x is x (mod)ulo f, aka remainder operation. f must be an non-zero atom, x can be anything.
-F(Tak,Qr(!af)_f(N(f,ax?x:sx[i%nx])))                //!< dyadic f#x is (tak)e, which has two variants based on the type of right operand (left must be atom):
+F(Tak,Qr(!af)_x(N(f,ax?x:sx[i%nx])))                //!< dyadic f#x is (tak)e, which has two variants based on the type of right operand (left must be atom):
                                                     //!<  if x is a vector, return first f items of x. if f exceeds the size of x, wrap around from the start.
                                                     //!<  if x is an atom, return a vector of length f filled with x.
 

--- a/a.h
+++ b/a.h
@@ -69,7 +69,7 @@ typedef unsigned char c;typedef unsigned long u;         //!< type c is a shorth
 #define fi x(f,xi)                                       //!< return i'th element of vector f or 0 if i is out of bounds
 
 //!error handling
-static const u Q=128;                                    //!< magic numer for error
+static const u Q=128;                                    //!< magic number for error
 #define Q(e)    if(Q==(e))R Q;                           //!< if some e evaluates to Q, return error
 #define Qe(s)   err((u)__FUNCTION__,(u)__LINE__,(u)s)    //!< shortcut for err(): pass function name and error string s
 #define Qs(e,s) if(e)R Qe(s);                            //!< error template: if some e evaluates to true, throw an error
@@ -88,7 +88,8 @@ static const u Q=128;                                    //!< magic numer for er
                                                          //!< u f=N(8,pow(2,i));   //!< f is (1,2,4,8,16,32,64,128,256)
                                                          //!< u y=N(8,xi==fi);     //!< y is (0,1,1,0,0,0,0,0)
 
-#define _f(e) r(e,_r(f))                                 //!< execute some (e)xpression, then decrement refcount of f, potentially releasing it, and (r)eturn f.
+#define _f(e) r(e,_r(f))                                 //!< execute some (e)xpression that presumably relies on f,
+                                                         //!< then decrement refcount of f, potentially releasing it, and (r)eturn the expression.
 #define _x(e) r(e,_r(x))                                 //!< ..same for x.
 
                                                          //!< \note it would make sense to redefine u as an alias for uintptr_t to reduce


### PR DESCRIPTION
P.S. could x?:y be used [here](https://github.com/kparc/ksimple/blob/bee802e1cbb4cfbb306bf42b077f923f725d9963/a.c#L116), with the condition inverted?
Same with assignment printing suppression [here](https://github.com/kparc/ksimple/blob/bee802e1cbb4cfbb306bf42b077f923f725d9963/a.c#L161-L162)

I also found the use of `r=` [here](https://github.com/kparc/ksimple/blob/bee802e1cbb4cfbb306bf42b077f923f725d9963/a.c#L130-L131) weird, could that be an `x` macro instead?

I also think a different ternary indentation in eval would be clearer, but that's a lot more personal preference.